### PR TITLE
Skip download if file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added ability to skip a download if a file with the same name exists at the
+  destination. [#16]
+
 ## [1.0.0] - 2022-03-29
 
 Initial version with the following feature set:
@@ -26,3 +31,4 @@ Initial version with the following feature set:
   - Display the total progress
 
 [1.0.0]: https://github.com/rgreinho/trauma/releases/tag/1.0.0
+[#16]: https://github.com/rgreinho/trauma/pull/16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "trauma"
 version = "1.0.0"
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 description = "Simplify and prettify HTTP downloads"
 homepage = "https://github.com/rgreinho/trauma"
 repository = "https://github.com/rgreinho/trauma"

--- a/examples/with-report.rs
+++ b/examples/with-report.rs
@@ -24,6 +24,7 @@ async fn main() -> Result<(), Report> {
     let fake = format!("{}.fake", &reqwest_rs);
     let downloads = vec![
         Download::try_from(reqwest_rs).unwrap(),
+        Download::try_from(reqwest_rs).unwrap(),
         Download::try_from(fake.as_str()).unwrap(),
     ];
     let downloader = DownloaderBuilder::new()
@@ -54,6 +55,10 @@ fn display_summary(summaries: &[Summary]) {
                 String::from("❌")
             }
             Status::NotStarted => String::from("🔜"),
+            Status::Skipped(s) => {
+                error = s.to_string();
+                String::from("⏭️")
+            }
         };
         table.add_row(vec![
             &s.download().filename,

--- a/src/download.rs
+++ b/src/download.rs
@@ -83,8 +83,9 @@ impl TryFrom<&str> for Download {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Status {
     Fail(String),
-    Success,
     NotStarted,
+    Skipped(String),
+    Success,
 }
 /// Represents a [`Download`] summary.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Add ability to skip a download if a file with the same name exists at
the destination.

Drive-by:
- Fixes the "License" field value in the toml file.

Fixes rgreinho/trauma#15
