### PR TITLE
Add the ability to customize the progress bars

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -84,7 +84,7 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to
 
 - Added ability to skip a download if a file with the same name exists at the
   destination. [#16]
+- Added ability to customize the progress bars [#24]
+  - Customize the format
+  - Customize the progression style
+  - Leave them on the screen or clear them upon completion
+  - Hide any or both of them
+  - Add preconfigured styles
 
 ## [1.0.0] - 2022-03-29
 
@@ -32,3 +38,4 @@ Initial version with the following feature set:
 
 [1.0.0]: https://github.com/rgreinho/trauma/releases/tag/1.0.0
 [#16]: https://github.com/rgreinho/trauma/pull/16
+[#24]: https://github.com/rgreinho/trauma/pull/24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,6 @@ http = "0.2.6"
 [dev-dependencies]
 color-eyre = "0.6.1"
 comfy-table = "5.0.1"
+console =  "0.15"
 opentelemetry = "0.17"
 tracing-subscriber = "0.3"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ to help monitoring the process.
 - Progress bar w/ [indicatif]
   - Display the individual progress
   - Display the total progress
+- Ability to customize the progress bars
+  - Customize the format
+  - Customize the progression style
+  - Leave them on the screen or clear them upon completion
+  - Hide any or both of them
+  - Add pre-configured styles
 
 ## Usage
 
@@ -88,7 +94,6 @@ As a result, I decided to write `trauma`.
 ### Potential ideas for future versions
 
 - Resume download
-- Optional progress bar
 - Support for other download protocol (i.e.: FTP)
 
 [indicatif]: https://github.com/console-rs/indicatif

--- a/examples/with-report.rs
+++ b/examples/with-report.rs
@@ -1,6 +1,6 @@
 //! Download files and show the report using comfy-table.
 //!
-//! Run with
+//! Run with:
 //!
 //! ```not_rust
 //! cargo run -q --example with-report

--- a/examples/with-style.rs
+++ b/examples/with-style.rs
@@ -1,0 +1,59 @@
+//! Changes the style of the downloader.
+//!
+//! Run with:
+//!
+//! ```not_rust
+//! cargo run -q --example with-style
+//! ```
+
+use console::style;
+use std::path::PathBuf;
+use trauma::{
+    download::Download,
+    downloader::{DownloaderBuilder, ProgressBarOpts, StyleOptions},
+    Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let debian_net_install =
+        "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-11.3.0-arm64-netinst.iso";
+    let downloads = vec![Download::try_from(debian_net_install).unwrap()];
+    let style_opts = StyleOptions::new(
+        // The main bar uses a predifined template and progression characters set.
+        ProgressBarOpts::new(
+            Some(ProgressBarOpts::TEMPLATE_BAR_WITH_POSITION.into()),
+            Some(ProgressBarOpts::CHARS_FINE.into()),
+            true,
+            false,
+        ),
+        // The child bar defines a custom template and a custom progression
+        // character set using unicode block characters.
+        // Other examples or symbols can easily be found online, for instance at:
+        // - https://changaco.oy.lc/unicode-progress-bars/
+        // - https://emojistock.com/circle-symbols/
+        ProgressBarOpts::new(
+            Some(
+                format!(
+                    "{{bar:40.cyan/blue}} {{percent:>2.magenta}}{} ● {{eta_precise:.blue}}",
+                    style("%").magenta(),
+                )
+                .into(),
+            ),
+            Some("●◕◑◔○".into()),
+            true,
+            false,
+        ),
+    );
+
+    // Predefined styles can also be used.
+    // let mut style_opts = StyleOptions::default();
+    // style_opts.set_child(ProgressBarOpts::with_pip_style());
+
+    let downloader = DownloaderBuilder::new()
+        .directory(PathBuf::from("output"))
+        .style_options(style_opts)
+        .build();
+    downloader.download(&downloads).await;
+    Ok(())
+}


### PR DESCRIPTION
Gives the user the ability to customize the visual aspects of the main
and/or the child progress bars. The bars can now also be disabled if
needed.

Fixes rgreinho/trauma#5
Fixes rgreinho/trauma#6
