### PR TITLE
Support for custom HTTP Headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"
@@ -11,20 +11,19 @@ categories = ["concurrency"]
 keywords = ["http", "download", "async", "tokio", "indicatif"]
 
 [dependencies]
-futures = "0.3.21"
-indicatif = "0.17.2"
-reqwest = { version = "0.11.9", features = ["stream", "socks"] }
+futures = "0.3.25"
+indicatif = "0.17.3"
+reqwest = { version = "0.11.13", features = ["stream", "socks"] }
 reqwest-middleware = "0.2.0"
 reqwest-retry = "0.2.1"
 reqwest-tracing = { version = "0.4.0", features = ["opentelemetry_0_17"] }
-task-local-extensions = "0.1.0"
-thiserror = "1.0.30"
+task-local-extensions = "0.1.3"
+thiserror = "1.0.38"
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = "0.3"
-tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
-url = "2.2.2"
-http = "0.2.6"
+tokio = { version = "1.24.1", features = ["macros", "rt-multi-thread"] }
+form_urlencoded = "1.1.0"
 
 [dev-dependencies]
 color-eyre = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.2.0"
+version = "2.1.1"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"

--- a/examples/with-report.rs
+++ b/examples/with-report.rs
@@ -20,7 +20,8 @@ async fn main() -> Result<(), Report> {
     color_eyre::install()?;
 
     // Download the file(s).
-    let reqwest_rs = "https://github.com/seanmonstar/reqwest/archive/refs/tags/v0.11.9.zip";
+    let reqwest_rs =
+        "https://github.com/seanmonstar/reqwest/archive/refs/tags/v0.11.9.zip";
     let fake = format!("{}.fake", &reqwest_rs);
     let downloads = vec![
         Download::try_from(reqwest_rs).unwrap(),
@@ -30,7 +31,9 @@ async fn main() -> Result<(), Report> {
     let downloader = DownloaderBuilder::new()
         .directory(PathBuf::from("output"))
         .build();
-    let summaries = downloader.download(&downloads).await;
+    let summaries = downloader
+        .download(&downloads)
+        .await;
 
     // Display results.
     display_summary(&summaries);
@@ -66,7 +69,6 @@ fn display_summary(summaries: &[Summary]) {
             &status,
             &error,
         ]);
-        ()
     });
     println!("{table}");
 }

--- a/examples/with-report.rs
+++ b/examples/with-report.rs
@@ -20,8 +20,7 @@ async fn main() -> Result<(), Report> {
     color_eyre::install()?;
 
     // Download the file(s).
-    let reqwest_rs =
-        "https://github.com/seanmonstar/reqwest/archive/refs/tags/v0.11.9.zip";
+    let reqwest_rs = "https://github.com/seanmonstar/reqwest/archive/refs/tags/v0.11.9.zip";
     let fake = format!("{}.fake", &reqwest_rs);
     let downloads = vec![
         Download::try_from(reqwest_rs).unwrap(),
@@ -31,9 +30,7 @@ async fn main() -> Result<(), Report> {
     let downloader = DownloaderBuilder::new()
         .directory(PathBuf::from("output"))
         .build();
-    let summaries = downloader
-        .download(&downloads)
-        .await;
+    let summaries = downloader.download(&downloads).await;
 
     // Display results.
     display_summary(&summaries);

--- a/examples/with-resume.rs
+++ b/examples/with-resume.rs
@@ -32,8 +32,7 @@ async fn main() -> Result<(), Report> {
         .init();
 
     // Prepare the download.
-    let avatar =
-        Url::parse("https://avatars.githubusercontent.com/u/6969134?v=4").unwrap();
+    let avatar = Url::parse("https://avatars.githubusercontent.com/u/6969134?v=4").unwrap();
     let output = PathBuf::from("output/avatar.jpg");
     fs::create_dir_all(output.parent().unwrap())?;
 
@@ -66,8 +65,7 @@ async fn main() -> Result<(), Report> {
     let mut stream = res.bytes_stream();
     let mut file = File::create(&output).await?;
     while let Some(item) = stream.next().await {
-        file.write_all_buf(&mut item?)
-            .await?;
+        file.write_all_buf(&mut item?).await?;
     }
     debug!("Retrieved {} bytes.", random_bytes);
 
@@ -83,16 +81,9 @@ async fn main() -> Result<(), Report> {
 
     // Hidding the progress bar because of the logging.
     let downloader = DownloaderBuilder::hidden()
-        .directory(
-            output
-                .parent()
-                .unwrap()
-                .to_path_buf(),
-        )
+        .directory(output.parent().unwrap().to_path_buf())
         .build();
-    downloader
-        .download(&downloads)
-        .await;
+    downloader.download(&downloads).await;
 
     Ok(())
 }

--- a/examples/with-resume.rs
+++ b/examples/with-resume.rs
@@ -6,17 +6,20 @@
 //! cargo run -q --example with-resume
 //! ```
 
-use color_eyre::{eyre::eyre, eyre::Report, Result};
+use color_eyre::{
+    eyre::{eyre, Report},
+    Result,
+};
 use futures::stream::StreamExt;
 use rand::Rng;
-use reqwest::header::{ACCEPT_RANGES, RANGE};
-use std::fs;
-use std::path::PathBuf;
+use reqwest::{
+    header::{ACCEPT_RANGES, RANGE},
+    Url,
+};
+use std::{fs, path::PathBuf};
 use tokio::{fs::File, io::AsyncWriteExt};
 use tracing::debug;
-use tracing_subscriber;
 use trauma::{download::Download, downloader::DownloaderBuilder};
-use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
@@ -29,7 +32,8 @@ async fn main() -> Result<(), Report> {
         .init();
 
     // Prepare the download.
-    let avatar = Url::parse("https://avatars.githubusercontent.com/u/6969134?v=4").unwrap();
+    let avatar =
+        Url::parse("https://avatars.githubusercontent.com/u/6969134?v=4").unwrap();
     let output = PathBuf::from("output/avatar.jpg");
     fs::create_dir_all(output.parent().unwrap())?;
 
@@ -47,7 +51,7 @@ async fn main() -> Result<(), Report> {
     tracing::debug!("Is the file resumable: {:?}", &resumable);
 
     // We must ensure that the download is resumable to prove our point.
-    assert_eq!(resumable, true);
+    assert!(resumable);
 
     // Request a random amount of data to simulate a previously failed download.
     let mut rng = rand::thread_rng();
@@ -62,7 +66,8 @@ async fn main() -> Result<(), Report> {
     let mut stream = res.bytes_stream();
     let mut file = File::create(&output).await?;
     while let Some(item) = stream.next().await {
-        file.write_all_buf(&mut item?).await?;
+        file.write_all_buf(&mut item?)
+            .await?;
     }
     debug!("Retrieved {} bytes.", random_bytes);
 
@@ -78,9 +83,16 @@ async fn main() -> Result<(), Report> {
 
     // Hidding the progress bar because of the logging.
     let downloader = DownloaderBuilder::hidden()
-        .directory(output.parent().unwrap().to_path_buf())
+        .directory(
+            output
+                .parent()
+                .unwrap()
+                .to_path_buf(),
+        )
         .build();
-    downloader.download(&downloads).await;
+    downloader
+        .download(&downloads)
+        .await;
 
     Ok(())
 }

--- a/examples/with-style.rs
+++ b/examples/with-style.rs
@@ -33,12 +33,10 @@ async fn main() -> Result<(), Error> {
         // - https://changaco.oy.lc/unicode-progress-bars/
         // - https://emojistock.com/circle-symbols/
         ProgressBarOpts::new(
-            Some(
-                format!(
-                    "{{bar:40.cyan/blue}} {{percent:>2.magenta}}{} ● {{eta_precise:.blue}}",
-                    style("%").magenta(),
-                ),
-            ),
+            Some(format!(
+                "{{bar:40.cyan/blue}} {{percent:>2.magenta}}{} ● {{eta_precise:.blue}}",
+                style("%").magenta(),
+            )),
             Some("●◕◑◔○".into()),
             true,
             false,
@@ -53,8 +51,6 @@ async fn main() -> Result<(), Error> {
         .directory(PathBuf::from("output"))
         .style_options(style_opts)
         .build();
-    downloader
-        .download(&downloads)
-        .await;
+    downloader.download(&downloads).await;
     Ok(())
 }

--- a/examples/with-style.rs
+++ b/examples/with-style.rs
@@ -37,8 +37,7 @@ async fn main() -> Result<(), Error> {
                 format!(
                     "{{bar:40.cyan/blue}} {{percent:>2.magenta}}{} ● {{eta_precise:.blue}}",
                     style("%").magenta(),
-                )
-                .into(),
+                ),
             ),
             Some("●◕◑◔○".into()),
             true,
@@ -54,6 +53,8 @@ async fn main() -> Result<(), Error> {
         .directory(PathBuf::from("output"))
         .style_options(style_opts)
         .build();
-    downloader.download(&downloads).await;
+    downloader
+        .download(&downloads)
+        .await;
     Ok(())
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -48,10 +48,7 @@ impl Download {
         &self,
         client: &ClientWithMiddleware,
     ) -> Result<bool, reqwest_middleware::Error> {
-        let res = client
-            .head(self.url.clone())
-            .send()
-            .await?;
+        let res = client.head(self.url.clone()).send().await?;
         let headers = res.headers();
         match headers.get(ACCEPT_RANGES) {
             None => Ok(false),
@@ -82,10 +79,7 @@ impl TryFrom<&Url> for Download {
                     .collect(),
             })
             .ok_or_else(|| {
-                Error::InvalidUrl(format!(
-                    "the url \"{}\" does not contain a filename",
-                    value
-                ))
+                Error::InvalidUrl(format!("the url \"{}\" does not contain a filename", value))
             })
     }
 }
@@ -96,10 +90,7 @@ impl TryFrom<&str> for Download {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Url::parse(value)
             .map_err(|e| {
-                Error::InvalidUrl(format!(
-                    "the url \"{}\" cannot be parsed: {}",
-                    value, e
-                ))
+                Error::InvalidUrl(format!("the url \"{}\" cannot be parsed: {}", value, e))
             })
             .and_then(|u| Download::try_from(&u))
     }
@@ -129,12 +120,7 @@ pub struct Summary {
 
 impl Summary {
     /// Create a new [`Download`] [`Summary`].
-    pub fn new(
-        download: Download,
-        statuscode: StatusCode,
-        size: u64,
-        resumable: bool,
-    ) -> Self {
+    pub fn new(download: Download, statuscode: StatusCode, size: u64, resumable: bool) -> Self {
         Self {
             download,
             statuscode,

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,10 +1,9 @@
 //! Represents a file to be downloaded.
 
 use crate::Error;
-use http::{header::ACCEPT_RANGES, StatusCode};
+use reqwest::{header::ACCEPT_RANGES, StatusCode, Url};
 use reqwest_middleware::ClientWithMiddleware;
 use std::convert::TryFrom;
-use url::Url;
 
 /// Represents a file to be downloaded.
 #[derive(Debug, Clone)]
@@ -78,7 +77,7 @@ impl TryFrom<&Url> for Download {
             .map(String::from)
             .map(|filename| Download {
                 url: value.clone(),
-                filename: url::form_urlencoded::parse(filename.as_bytes())
+                filename: form_urlencoded::parse(filename.as_bytes())
                     .map(|(key, val)| [key, val].concat())
                     .collect(),
             })

--- a/src/download.rs
+++ b/src/download.rs
@@ -28,7 +28,7 @@ impl Download {
     /// ```no_run
     /// # use color_eyre::{eyre::Report, Result};
     /// use trauma::download::Download;
-    /// use url::Url;
+    /// use reqwest::Url;
     ///
     /// # fn main() -> Result<(), Report> {
     /// Download::try_from("https://example.com/file-0.1.2.zip")?;

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,8 +1,7 @@
 //! Represents a file to be downloaded.
 
 use crate::Error;
-use http::header::ACCEPT_RANGES;
-use http::StatusCode;
+use http::{header::ACCEPT_RANGES, StatusCode};
 use reqwest_middleware::ClientWithMiddleware;
 use std::convert::TryFrom;
 use url::Url;
@@ -50,7 +49,10 @@ impl Download {
         &self,
         client: &ClientWithMiddleware,
     ) -> Result<bool, reqwest_middleware::Error> {
-        let res = client.head(self.url.clone()).send().await?;
+        let res = client
+            .head(self.url.clone())
+            .send()
+            .await?;
         let headers = res.headers();
         match headers.get(ACCEPT_RANGES) {
             None => Ok(false),
@@ -81,7 +83,10 @@ impl TryFrom<&Url> for Download {
                     .collect(),
             })
             .ok_or_else(|| {
-                Error::InvalidUrl(format!("the url \"{}\" does not contain a filename", value))
+                Error::InvalidUrl(format!(
+                    "the url \"{}\" does not contain a filename",
+                    value
+                ))
             })
     }
 }
@@ -92,7 +97,10 @@ impl TryFrom<&str> for Download {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Url::parse(value)
             .map_err(|e| {
-                Error::InvalidUrl(format!("the url \"{}\" cannot be parsed: {}", value, e))
+                Error::InvalidUrl(format!(
+                    "the url \"{}\" cannot be parsed: {}",
+                    value, e
+                ))
             })
             .and_then(|u| Download::try_from(&u))
     }
@@ -122,7 +130,12 @@ pub struct Summary {
 
 impl Summary {
     /// Create a new [`Download`] [`Summary`].
-    pub fn new(download: Download, statuscode: StatusCode, size: u64, resumable: bool) -> Self {
+    pub fn new(
+        download: Download,
+        statuscode: StatusCode,
+        size: u64,
+        resumable: bool,
+    ) -> Self {
         Self {
             download,
             statuscode,
@@ -180,7 +193,7 @@ impl Summary {
 mod test {
     use super::*;
 
-    const DOMAIN: &'static str = "http://domain.com/file.zip";
+    const DOMAIN: &str = "http://domain.com/file.zip";
 
     #[test]
     fn test_try_from_url() {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -2,9 +2,9 @@
 
 use crate::download::{Download, Status, Summary};
 use futures::stream::{self, StreamExt};
-use http::{
-    header::{IntoHeaderName, RANGE},
-    HeaderMap, HeaderValue, StatusCode,
+use reqwest::{
+    header::{IntoHeaderName, RANGE,HeaderMap, HeaderValue},
+   StatusCode,
 };
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};


### PR DESCRIPTION
# Pull Request

## Types of changes

<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->

- New feature (Support for custom HTTP Headers)
- Chore (Upgrade and simplify deps)

## Description

close https://github.com/rgreinho/trauma/issues/52

### About feature:

Added `.headers()` and `.header()` for `DownloaderBuilder`.
We can either call the `.header()` multiple times to add multiple headers, or we can add a bunch of `headers` with `.headers()`.

```rust
   use reqwest::{
            header::{self, HeaderValue},
        };

    const FIREFOX_UA: &str =
        "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0";

    let ua = HeaderValue::from_str(FIREFOX_UA).expect("Invalid UA");

    let client = DownloaderBuilder::new()
        .directory(PathBuf::from("assets"))
        .header(header::USER_AGENT, ua)
        .build();
```


### About dependencies:

`http::header` -> `reqwest::header`
`url::Url` -> `reqwest::Url`

Reducing external dependencies makes maintenance easier, as well as reducing the probability of dependency conflicts.


<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [x] I have updated the documentation accordingly
- [] I have updated the Changelog (if applicable)

<!--
Place the URL of the issue here if this PR fixes an existing issue.
Use either the `username/repository#` syntax (preferred) or the *FULL* URL.
-->

