### PR TITLE
Prepare the code base for 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.2.0] - 2022-01-21
+
+### Added
+
+- Added the ability to provide custom HTTP headers to the downloader. [#53]
+
+[#53]: https://github.com/rgreinho/trauma/pull/53
+[2.2.0]: https://github.com/rgreinho/trauma/releases/tag/2.2.0
+
 ## [2.1.1] - 2022-11-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"


### PR DESCRIPTION
Prepares the code base for 2.2.0 release.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
