### PR TITLE
Fixed Issue #55

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -184,7 +184,11 @@ impl Downloader {
         };
 
         // Update the summary with the collected details.
-        let size = res.content_length().unwrap_or_default();
+        let size = res.content_length().unwrap_or(u64::MAX);
+        // ^^^ The default u64 value is 0, which will instantly skip a download
+        //     For this reason we set it to an unreasonably high value instead
+        //     of using `unwrap_or_default`. This ensures downloads won't be
+        //     skipped for no reason.
         let status = res.status();
         summary = Summary::new(download.clone(), status, size, can_resume);
 

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -216,12 +216,6 @@ impl Downloader {
         };
 
         debug!("Creating destination file {:?}", &output);
-        // append: If we can't resume from where we left off,
-        //         we should overrwite the file and start again
-        //         This also prevents corrupting files by writing
-        //         to them again
-        // write:  We are writing to the file
-        // create: The file should be created if it doesn't exist
         let mut file = match OpenOptions::new()
             .append(can_resume)
             .write(true) 
@@ -272,7 +266,6 @@ impl Downloader {
         main.inc(1);
 
         // Create a new summary with the real download size
-        println!("Size on disk {}", size_on_disk);
         let summary = Summary::new(download.clone(), status, final_size, can_resume);
         // Return the download summary.
         summary.with_status(Status::Success)

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -228,6 +228,8 @@ impl Downloader {
             }
         };
 
+        let mut final_size = size_on_disk;
+
         // Download the file chunk by chunk.
         debug!("Retrieving chunks...");
         let mut stream = res.bytes_stream();
@@ -239,7 +241,9 @@ impl Downloader {
                     return summary.fail(e);
                 }
             };
-            pb.inc(chunk.len() as u64);
+            let chunk_size = chunk.len() as u64;
+            final_size += chunk_size;
+            pb.inc(chunk_size);
 
             // Write the chunk to disk.
             match file.write_all_buf(&mut chunk).await {
@@ -261,7 +265,8 @@ impl Downloader {
         main.inc(1);
 
         // Create a new summary with the real download size
-        let summary = Summary::new(download.clone(), status, size_on_disk, can_resume);
+        println!("Size on disk {}", size_on_disk);
+        let summary = Summary::new(download.clone(), status, final_size, can_resume);
         // Return the download summary.
         summary.with_status(Status::Success)
     }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -264,6 +264,8 @@ impl Downloader {
         // Advance the main progress bar.
         main.inc(1);
 
+        // Create a new summary with the real download size
+        let summary = Summary::new(download.clone(), status, size_on_disk, can_resume);
         // Return the download summary.
         summary.with_status(Status::Success)
     }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -184,16 +184,12 @@ impl Downloader {
         };
 
         // Update the summary with the collected details.
-        let size = res.content_length().unwrap_or(u64::MAX);
-        // ^^^ The default u64 value is 0, which will instantly skip a download
-        //     For this reason we set it to an unreasonably high value instead
-        //     of using `unwrap_or_default`. This ensures downloads won't be
-        //     skipped for no reason.
+        let size = res.content_length().unwrap_or_default();
         let status = res.status();
         summary = Summary::new(download.clone(), status, size, can_resume);
 
         // If there is nothing else to download for this file, we can return.
-        if size == size_on_disk {
+        if size_on_disk > 0 && size == size_on_disk {
             return summary.with_status(Status::Skipped(
                 "the file was already fully downloaded".into(),
             ));

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -217,9 +217,9 @@ impl Downloader {
 
         debug!("Creating destination file {:?}", &output);
         let mut file = match OpenOptions::new()
-            .append(can_resume)
-            .write(true) 
             .create(true)
+            .write(true)
+            .append(can_resume)
             .open(output)
             .await
         {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -216,8 +216,15 @@ impl Downloader {
         };
 
         debug!("Creating destination file {:?}", &output);
+        // append: If we can't resume from where we left off,
+        //         we should overrwite the file and start again
+        //         This also prevents corrupting files by writing
+        //         to them again
+        // write:  We are writing to the file
+        // create: The file should be created if it doesn't exist
         let mut file = match OpenOptions::new()
-            .append(true)
+            .append(can_resume)
+            .write(true) 
             .create(true)
             .open(output)
             .await


### PR DESCRIPTION
# Pull Request

## Types of changes

Fixed issue [#55](https://github.com/rgreinho/trauma/issues/55)

## Description

### Summary

1. Changed the default file size value from 0 to `u64::MAX` in order to prevent downloads without a `content-length` being skipped for no reason.
2. On a successful download, the file size on disk is returned as opposed to the potentially inaccurate value that came from `content-length`

### Original
![image](https://user-images.githubusercontent.com/57483028/222959987-8c40d89b-3b78-4c3e-b86c-a92e5449bd61.png)
![image](https://user-images.githubusercontent.com/57483028/222960783-21b9c43a-f7a6-4d59-8763-cd1e5aee6763.png)

### Current
![image](https://user-images.githubusercontent.com/57483028/222959960-4da064b6-d5ac-4768-9445-f14974dbed50.png)
![image](https://user-images.githubusercontent.com/57483028/222960733-04f29061-30bc-40f6-a5bd-f0b4251902c8.png)

## Fixed

[Issue #55](https://github.com/rgreinho/trauma/issues/55) (files that hadn't been downloaded were being skipped)

## Testing

Essentially just the simple example with several different files; the change was very minor (basically a value was changed from 0 to `u64::MAX`, logically everything checks out, and in testing there were no issues)

## Checklist

- [x] I have updated the documentation accordingly **(only code comments needed changing)**
- [ ] I have updated the Changelog (if applicable) **(N/A)**

[Issue #55](https://github.com/rgreinho/trauma/issues/55)