### PR TITLE
Prepare codebase for 2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.2.1] - 2023-03-06
+
+### Fixed
+
+- Handled the case when the server does not send a `content-length` header,
+  causing downloads to be skipped. [#56]
+
+[#56]: https://github.com/rgreinho/trauma/pull/56
+
 ## [2.2.0] - 2022-01-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ monitoring the process.
   - Maximum simultaneous requests
   - Number of retries
   - Resume downloads (if supported by the remote server)
+  - Custom HTTP Headers
 - Asynchronous w/ [Tokio]
 - Progress bar w/ [indicatif]
   - Display the individual progress

--- a/SLSA.md
+++ b/SLSA.md
@@ -323,7 +323,8 @@ about a platform admin, so it may no apply here.
 [build - build as code]: https://slsa.dev/spec/v0.1/requirements#build-as-code
 [build - isolated]: https://slsa.dev/spec/v0.1/requirements#isolated
 [build - build service]: https://slsa.dev/spec/v0.1/requirements#build-service
-[build - ephemeral environment]: https://slsa.dev/spec/v0.1/requirements#ephemeral-environment
+[build - ephemeral environment]:
+  https://slsa.dev/spec/v0.1/requirements#ephemeral-environment
 [build - hermetic]: https://slsa.dev/spec/v0.1/requirements#hermetic
 [build - reproducible]: https://slsa.dev/spec/v0.1/requirements#reproducible
 [build - parameterless]: https://slsa.dev/spec/v0.1/requirements#parameterless
@@ -334,16 +335,25 @@ about a platform admin, so it may no apply here.
 [cosign]: https://github.com/sigstore/cosign
 [fulcio]: https://github.com/sigstore/fulcio
 [github-actions-demo]: https://github.com/slsa-framework/github-actions-demo
-[github hosted runners]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+[github hosted runners]:
+  https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
 [openid signing]: https://docs.sigstore.dev/cosign/openid_signing
-[provenance - authenticated]: https://slsa.dev/spec/v0.1/requirements#authenticated
+[provenance - authenticated]:
+  https://slsa.dev/spec/v0.1/requirements#authenticated
 [provenance - available]: https://slsa.dev/spec/v0.1/requirements#available
-[provenance - dependencies complete]: https://slsa.dev/spec/v0.1/requirements#dependencies-complete
-[provenance - non-falsifiable]: https://slsa.dev/spec/v0.1/requirements#non-falsifiable
-[provenance - service generated]: https://slsa.dev/spec/v0.1/requirements#service-generated
+[provenance - dependencies complete]:
+  https://slsa.dev/spec/v0.1/requirements#dependencies-complete
+[provenance - non-falsifiable]:
+  https://slsa.dev/spec/v0.1/requirements#non-falsifiable
+[provenance - service generated]:
+  https://slsa.dev/spec/v0.1/requirements#service-generated
 [rekor]: https://github.com/sigstore/rekor
 [slsa]: https://slsa.dev/
-[source - retained indefinitely]: https://slsa.dev/spec/v0.1/requirements#retained-indefinitely
-[source - two-person reviewed]: https://slsa.dev/spec/v0.1/requirements#two-person-reviewed
-[source - version controlled]: https://slsa.dev/spec/v0.1/requirements#version-controlled
-[source - verified history]: https://slsa.dev/spec/v0.1/requirements#verified-history
+[source - retained indefinitely]:
+  https://slsa.dev/spec/v0.1/requirements#retained-indefinitely
+[source - two-person reviewed]:
+  https://slsa.dev/spec/v0.1/requirements#two-person-reviewed
+[source - version controlled]:
+  https://slsa.dev/spec/v0.1/requirements#version-controlled
+[source - verified history]:
+  https://slsa.dev/spec/v0.1/requirements#verified-history


### PR DESCRIPTION
Prepares the codebase for 2.2.1 release.

Drive-by:
- Reformats the Markdown files.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
