### PR TITLE
Fix download indicator

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -184,7 +184,7 @@ impl Downloader {
         };
 
         // Update the summary with the collected details.
-        let size = res.content_length().unwrap_or_default();
+        let size = res.content_length().unwrap_or_default() + size_on_disk;
         let status = res.status();
         summary = Summary::new(download.clone(), status, size, can_resume);
 


### PR DESCRIPTION
Fixes the final size when resuming a download.

Fixes rgreinho/trauma#59

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
