### PR TITLE
Ensure all Downloader requests use same headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-**/*.rs.bk
 .DS_Store
+**/*.rs.bk
 /output/
 /target
 /target/
 Cargo.lock
+examples/miniserve/

--- a/examples/with-authentication.rs
+++ b/examples/with-authentication.rs
@@ -1,0 +1,46 @@
+//! Download a file with authentication example.
+//!
+//! Setup for this example:
+//!
+//! From the root of the project:
+//! ```not_rust
+//! mkdir -p examples/miniserve
+//! cd examples/miniserve
+//! curl -sLO https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-11.7.0-arm64-netinst.iso
+//! miniserve --auth trauma:test .
+//! ```
+//!
+//! Then from another terminal:
+//!
+//! ```not_rust
+//! cargo run -q --example simple
+//! ```
+//!
+//! The value for the authentication header can be generated from the command line:
+//! ```not_rust
+//! echo -n "trauma:test"|base64
+//! ```
+//! Or from a website like https://www.debugbear.com/basic-auth-header-generator.
+//!
+//! Miniserve is a utility written in rust to serve files over HTTP:
+//! https://github.com/svenstaro/miniserve
+//!
+
+use reqwest::header::{self, HeaderValue};
+use std::path::PathBuf;
+use trauma::{download::Download, downloader::DownloaderBuilder, Error};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let reqwest_rs = "http://localhost:8080/debian-11.7.0-arm64-netinst.iso";
+    let downloads = vec![Download::try_from(reqwest_rs).unwrap()];
+    let auth = HeaderValue::from_str("Basic dHJhdW1hOnRlc3Q=").expect("Invalid auth");
+    let downloader = DownloaderBuilder::new()
+        .directory(PathBuf::from("output"))
+        .header(header::AUTHORIZATION, auth)
+        .build();
+    let summaries = downloader.download(&downloads).await;
+    let summary = summaries.first().unwrap();
+    println!("{:?}", summary.status());
+    Ok(())
+}

--- a/examples/with-style.rs
+++ b/examples/with-style.rs
@@ -17,7 +17,7 @@ use trauma::{
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let debian_net_install =
-        "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-11.3.0-arm64-netinst.iso";
+        "https://cdimage.debian.org/debian-cd/current/arm64/iso-cd/debian-11.7.0-arm64-netinst.iso";
     let downloads = vec![Download::try_from(debian_net_install).unwrap()];
     let style_opts = StyleOptions::new(
         // The main bar uses a predifined template and progression characters set.


### PR DESCRIPTION
Ensures all requests of downloader use the same headers, so that for
instance, the authentication is preserved.

Fixes rgreinho/trauma#62

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
