### PR TITLE
Fix download with path as a filename

### DIFF
--- a/examples/with-path-as-filename.rs
+++ b/examples/with-path-as-filename.rs
@@ -1,0 +1,22 @@
+//! Download example using a target filename with a path.
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run -q --example with-path-as-filename
+//! ```
+use trauma::{download::Download, downloader::DownloaderBuilder, Error};
+
+use reqwest::Url;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let reqwest_rs = "https://github.com/seanmonstar/reqwest/archive/refs/tags/v0.11.9.zip";
+    let downloads = vec![Download {
+        url: Url::parse(reqwest_rs).unwrap(),
+        filename: "output/test_dir/reqwest.zip".to_string(),
+    }];
+    let downloader = DownloaderBuilder::new().build();
+    downloader.download(&downloads).await;
+    Ok(())
+}

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -214,8 +214,9 @@ impl Downloader {
         );
 
         // Prepare the destination directory/file.
-        debug!("Creating destination directory {:?}", &self.directory);
-        match fs::create_dir_all(&self.directory) {
+        let output_dir = output.parent().unwrap_or(&output);
+        debug!("Creating destination directory {:?}", output_dir);
+        match fs::create_dir_all(output_dir) {
             Ok(_res) => (),
             Err(e) => {
                 return summary.fail(e);


### PR DESCRIPTION
Ensures target filenames with a path are downloaded correctly.

Fixes rgreinho/trauma#73

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
