### PR TITLE
Handle 416 status when file is fully downloaded

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Disable some built-in rules.
-no-duplicate-header:
-  allow_different_nesting: true
+headings:
+  siblings_only: true
 line-length:
   tables: false
   code_blocks: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Handled 416 status when a file is already fully downloaded. [#86]
+
+[#86]: https://github.com/rgreinho/trauma/pull/86
+
 ## [2.2.4]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ keywords = ["http", "download", "async", "tokio", "indicatif"]
 [dependencies]
 futures = "0.3.25"
 indicatif = "0.17.3"
-reqwest = { version = "0.11.13", features = ["stream", "socks"] }
-reqwest-middleware = "0.2.0"
+reqwest = { version = "0.11.24", features = ["stream", "socks"] }
+reqwest-middleware = "0.2.4"
 reqwest-retry = "0.3.0"
-reqwest-tracing = { version = "0.4.0", features = ["opentelemetry_0_17"] }
+reqwest-tracing = { version = "0.4.7", features = ["opentelemetry_0_17"] }
 task-local-extensions = "0.1.3"
 thiserror = "1.0.38"
 tracing = "0.1"
 tracing-opentelemetry = "0.22"
 tracing-subscriber = "0.3"
-tokio = { version = "1.24.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 form_urlencoded = "1.1.0"
 
 [dev-dependencies]

--- a/examples/with-range-error-handling.rs
+++ b/examples/with-range-error-handling.rs
@@ -1,0 +1,34 @@
+//! Range error handling example.
+//!
+//! Setup for this example:
+//!
+//! From the root of the project:
+//! ```not_rust
+//! mkdir -p examples/miniserve
+//! cd examples/miniserve
+//! curl -sLO http://212.183.159.230/5MB.zip
+//! miniserve .
+//! ```
+//! Run with:
+//!
+//! ```not_rust
+//! cargo run -q --example range-error-handling
+//! ```
+//!
+//! Miniserve is a utility written in rust to serve files over HTTP:
+//! https://github.com/svenstaro/miniserve
+
+use std::path::PathBuf;
+use trauma::{download::Download, downloader::DownloaderBuilder, Error};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let five_mb = "http://localhost:8080/5MB.zip";
+    let downloads = vec![Download::try_from(five_mb).unwrap()];
+    let downloader = DownloaderBuilder::new()
+        .directory(PathBuf::from("output"))
+        .build();
+    let summary = downloader.download(&downloads).await;
+    dbg!(summary);
+    Ok(())
+}


### PR DESCRIPTION
Handles the 416 status code (Range Not Satisfiable) when the file is
already present on disk and fully downloaded.

Fixes rgreinho/trauma#84

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>