### PR TITLE
Updates reqwest to 0.12 and its dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["http", "download", "async", "tokio", "indicatif"]
 [dependencies]
 futures = "0.3.25"
 indicatif = "0.17.3"
-reqwest = { version = "0.11.24", features = ["stream", "socks"] }
-reqwest-middleware = "0.2.4"
-reqwest-retry = "0.4.0"
-reqwest-tracing = { version = "0.4.7", features = ["opentelemetry_0_17"] }
+reqwest = { version = "0.12.4", features = ["stream", "socks"] }
+reqwest-middleware = "0.3.1"
+reqwest-retry = "0.5.0"
+reqwest-tracing = "0.5.0"
 task-local-extensions = "0.1.3"
 thiserror = "1.0.38"
 tracing = "0.1"
-tracing-opentelemetry = "0.23"
+tracing-opentelemetry = "0.24"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 form_urlencoded = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ indicatif = "0.17.3"
 reqwest = { version = "0.12.4", features = ["stream", "socks"] }
 reqwest-middleware = "0.3.1"
 reqwest-retry = "0.5.0"
-reqwest-tracing = "0.5.0"
+reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_22"] }
 task-local-extensions = "0.1.3"
 thiserror = "1.0.38"
 tracing = "0.1"


### PR DESCRIPTION
# Pull Request

## Types of changes

- Infrastructure and automation

## Description
This PR updates reqwest and the middleware dependencies.

All dependencies have to be updated at the same time or it will not work, as can be seen by the failed open PRs by dependentbot.

With this PR,  dependentBot can continue upgrading the dependencies again.

Nothing more is changed, tests still run. I did test it by running all examples and cargo test.

## Checklist

- [x] I have updated the documentation accordingly
nothing has to be documentent imo
- [x] I have updated the Changelog (if applicable)
nothing has changed, it is housekeeping work.


edit and p.s.: the github project description hast a captial letter too much, written there is "Universal download MAnager "