### PR TITLE
Release 2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.2.5]
+
 ### Fixed
 
 - Handled 416 status when a file is already fully downloaded. [#86]
 
 [#86]: https://github.com/rgreinho/trauma/pull/86
+[2.2.5]: https://github.com/rgreinho/trauma/releases/tag/2.2.5
 
 ## [2.2.4]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"
@@ -11,6 +11,7 @@ categories = ["concurrency"]
 keywords = ["http", "download", "async", "tokio", "indicatif"]
 
 [dependencies]
+form_urlencoded = "1.1.0"
 futures = "0.3.25"
 indicatif = "0.17.3"
 reqwest = { version = "0.12.4", features = ["stream", "socks"] }
@@ -19,11 +20,10 @@ reqwest-retry = "0.5.0"
 reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_22"] }
 task-local-extensions = "0.1.3"
 thiserror = "1.0.38"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.24"
 tracing-subscriber = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-form_urlencoded = "1.1.0"
 
 [dev-dependencies]
 color-eyre = "0.6.1"


### PR DESCRIPTION
Prepares the codebase for 2.2.5 release.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
