### PR TITLE
Pin package version of `reqwest-tracing` to fix build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ indicatif = "0.17.3"
 reqwest = { version = "0.12.4", features = ["stream", "socks"] }
 reqwest-middleware = "0.3.1"
 reqwest-retry = "0.6.0"
-reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_22"] }
+reqwest-tracing = { version = "=0.5.3", features = ["opentelemetry_0_22"] }
 task-local-extensions = "0.1.3"
 thiserror = "2.0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
`reqwest-tracing` recently had an update from `0.5.3` to `0.5.4`, which broke builds for this project. I'm pinning the dependency version to allow it to compile for now.

To reproduce, run `cargo update` to update dependencies in the cargo.lock, then `cargo build`.