### PR TITLE
Prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.3.0] - 2025-06-14
+
+### Changed
+
+- Added feature to support Rustls. [#124]
+
+[#124]: https://github.com/rgreinho/trauma/pull/124
+[2.3.0]: https://github.com/rgreinho/trauma/releases/tag/2.3.0
+
 ## [2.2.6] - 2024-11-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trauma"
-version = "2.2.6"
+version = "2.3.0"
 edition = "2021"
 license = "MIT"
 description = "Simplify and prettify HTTP downloads"


### PR DESCRIPTION
Prepares the code base for 2.3.0 release.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
