### PR TITLE
refactor: removes clippy warnings

### DIFF
--- a/examples/with-resume.rs
+++ b/examples/with-resume.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Report> {
     let random_bytes: u8 = rng.random();
     let res = reqwest::Client::new()
         .get(avatar.to_string())
-        .header(RANGE, format!("bytes=0-{}", random_bytes))
+        .header(RANGE, format!("bytes=0-{random_bytes}"))
         .send()
         .await?;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -90,10 +90,7 @@ impl TryFrom<&Url> for Download {
         value
             .path_segments()
             .ok_or_else(|| {
-                Error::InvalidUrl(format!(
-                    "the url \"{}\" does not contain a valid path",
-                    value
-                ))
+                Error::InvalidUrl(format!("the url \"{value}\" does not contain a valid path"))
             })?
             .next_back()
             .map(String::from)
@@ -104,7 +101,7 @@ impl TryFrom<&Url> for Download {
                     .collect(),
             })
             .ok_or_else(|| {
-                Error::InvalidUrl(format!("the url \"{}\" does not contain a filename", value))
+                Error::InvalidUrl(format!("the url \"{value}\" does not contain a filename"))
             })
     }
 }
@@ -114,9 +111,7 @@ impl TryFrom<&str> for Download {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Url::parse(value)
-            .map_err(|e| {
-                Error::InvalidUrl(format!("the url \"{}\" cannot be parsed: {}", value, e))
-            })
+            .map_err(|e| Error::InvalidUrl(format!("the url \"{value}\" cannot be parsed: {e}")))
             .and_then(|u| Download::try_from(&u))
     }
 }
@@ -182,7 +177,7 @@ impl Summary {
 
     pub fn fail(self, msg: impl std::fmt::Display) -> Self {
         Self {
-            status: Status::Fail(format!("{}", msg)),
+            status: Status::Fail(format!("{msg}")),
             ..self
         }
     }

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -178,7 +178,7 @@ impl Downloader {
         debug!("Fetching {}", &download.url);
         let mut req = client.get(download.url.clone());
         if self.resumable && can_resume {
-            req = req.header(RANGE, format!("bytes={}-", size_on_disk));
+            req = req.header(RANGE, format!("bytes={size_on_disk}-"));
         }
 
         // Add extra headers if needed.


### PR DESCRIPTION
# Pull Request

## Types of changes

- Code cleanup / Refactoring
- Infrastructure and automation

## Description

Fixes clippy warnings, so that the CI can run again and doesn't fail.

This allows dependabot to work correct again. See also 
https://github.com/rgreinho/trauma/pull/128  
https://github.com/rgreinho/trauma/pull/127  

