### PR TITLE
feat: add per-download message display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
+unicode-width = "0.2"
 
 [dev-dependencies]
 color-eyre = "0.6.5"

--- a/examples/with-path-as-filename.rs
+++ b/examples/with-path-as-filename.rs
@@ -15,6 +15,7 @@ async fn main() -> Result<(), Error> {
     let downloads = vec![Download {
         url: Url::parse(reqwest_rs).unwrap(),
         filename: "output/test_dir/reqwest.zip".to_string(),
+        tag: None,
     }];
     let downloader = DownloaderBuilder::new().build();
     downloader.download(&downloads).await;

--- a/examples/with-tag.rs
+++ b/examples/with-tag.rs
@@ -1,0 +1,57 @@
+//! Demonstrates per-download progress bar labels using `Download.tag`
+//! and the `display_tag` option on the downloader.
+//!
+//! Run with:
+//!
+//! ```not_rust
+//! cargo run -q --example with-tag
+//! ```
+
+use std::path::PathBuf;
+use trauma::{
+    download::Download,
+    downloader::{DownloaderBuilder, StyleOptions},
+    Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let url_a =
+        "https://github.com/lxl66566/GalgameManager/releases/download/v1.1.1/GalgameManager_1.1.1_x64_en-US.msi";
+    let url_b = "https://github.com/lxl66566/GalgameManager/releases/download/v1.1.1/GalgameManager_1.1.1_amd64.AppImage";
+
+    let default_label = Download::try_from(url_a).unwrap();
+    let custom_label = Download::try_from(url_b)
+        .unwrap()
+        .with_tag("Galgame Manager");
+
+    // display_tag = true
+    //
+    // Tags are left-aligned to the width of the longest one so bars line up:
+    //
+    // GalgameManager_1.1.1_x64_en-US.msi ━━╾─────────────────────────────────────    1.05 MiB/14.28 MiB
+    // Galgame Manager                    ━━━╴────────────────────────────────────    1.10 MiB/14.28 MiB
+    //
+    // If no tag is set, the filename is used as a fallback.
+    println!("=== Pass A: display_tag = true ===\n");
+    let downloader = DownloaderBuilder::new()
+        .directory(PathBuf::from("output"))
+        .style_options(StyleOptions::default())
+        .build();
+    downloader
+        .download(&[default_label.clone(), custom_label.clone()])
+        .await;
+
+    // display_tag = false
+    //
+    // No tag prefix is prepended
+    println!("\n=== Pass B: display_tag = false ===\n");
+    let downloader = DownloaderBuilder::new()
+        .directory(PathBuf::from("output"))
+        .style_options(StyleOptions::default())
+        .display_tag(false)
+        .build();
+    downloader.download(&[default_label, custom_label]).await;
+
+    Ok(())
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -15,6 +15,9 @@ pub struct Download {
     pub url: Url,
     /// File name used to save the file on disk.
     pub filename: String,
+    /// Optional tag used as the progress bar message text for each download.
+    /// Falls back to `filename` if not set.
+    pub tag: Option<String>,
 }
 
 impl Download {
@@ -39,11 +42,25 @@ impl Download {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(url: &Url, filename: &str) -> Self {
+    pub fn new(url: &Url, filename: impl Into<String>) -> Self {
         Self {
             url: url.clone(),
-            filename: String::from(filename),
+            filename: filename.into(),
+            tag: None,
         }
+    }
+
+    /// Set the download tag.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use trauma::download::Download;
+    /// let d = Download::try_from("https://example.com/file-0.1.2.zip").unwrap().with_tag("my custom tag");
+    /// ```
+    pub fn with_tag(mut self, tag: impl Into<String>) -> Self {
+        self.tag = Some(tag.into());
+        self
     }
 
     /// Check whether the download is resumable.
@@ -99,6 +116,7 @@ impl TryFrom<&Url> for Download {
                 filename: form_urlencoded::parse(filename.as_bytes())
                     .map(|(key, val)| [key, val].concat())
                     .collect(),
+                tag: None,
             })
             .ok_or_else(|| {
                 Error::InvalidUrl(format!("the url \"{value}\" does not contain a filename"))

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -13,6 +13,7 @@ use reqwest_tracing::TracingMiddleware;
 use std::{fs, path::PathBuf, sync::Arc};
 use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 use tracing::debug;
+use unicode_width::UnicodeWidthStr;
 
 pub struct TimeTrace;
 
@@ -41,6 +42,8 @@ pub struct Downloader {
     resumable: bool,
     /// Custom HTTP headers.
     headers: Option<HeaderMap>,
+    /// Whether to display per-download tags on child progress bars.
+    display_tag: bool,
 }
 
 impl Downloader {
@@ -102,9 +105,18 @@ impl Downloader {
         );
         main.tick();
 
+        let tag_width = if self.display_tag {
+            downloads
+                .iter()
+                .map(|d| UnicodeWidthStr::width(d.tag.as_deref().unwrap_or(&d.filename)))
+                .max()
+        } else {
+            None
+        };
+
         // Download the files asynchronously.
         let summaries = stream::iter(downloads)
-            .map(|d| self.fetch(&client, d, multi.clone(), main.clone()))
+            .map(|d| self.fetch(&client, d, multi.clone(), main.clone(), tag_width))
             .buffer_unordered(self.concurrent_downloads)
             .collect::<Vec<_>>()
             .await;
@@ -127,6 +139,7 @@ impl Downloader {
         download: &Download,
         multi: Arc<MultiProgress>,
         main: Arc<ProgressBar>,
+        tag_width: Option<usize>,
     ) -> Summary {
         // Create a download summary.
         let mut size_on_disk: u64 = 0;
@@ -228,13 +241,25 @@ impl Downloader {
         // Create the progress bar.
         // If the download is being resumed, the progress bar position is
         // updated to start where the download stopped before.
-        let pb = multi.add(
-            self.style_options
-                .child
-                .clone()
-                .to_progress_bar(size)
-                .with_position(size_on_disk),
-        );
+        let mut child_opts = self.style_options.child.clone();
+
+        // tag_width is Some means we are displaying tags, so we prepend `{msg:<N} ` to the child template.
+        if let Some(width) = tag_width {
+            let tag_prefix = format!("{{msg:<{width}}} ");
+            child_opts.template = child_opts.template.map(|t| format!("{tag_prefix}{t}"));
+        }
+
+        let pb = multi.add(child_opts.to_progress_bar(size).with_position(size_on_disk));
+
+        if tag_width.is_some() {
+            pb.set_message(
+                download
+                    .tag
+                    .as_deref()
+                    .unwrap_or(&download.filename)
+                    .to_string(),
+            );
+        }
 
         // Prepare the destination directory/file.
         let output_dir = output.parent().unwrap_or(&output);
@@ -353,6 +378,15 @@ impl DownloaderBuilder {
         self
     }
 
+    /// Set whether to display per-download tags on child progress bars.
+    ///
+    /// When enabled, each child bar prepends a left-aligned tag (or filename
+    /// fallback) padded to the width of the longest one so all bars align.
+    pub fn display_tag(mut self, show: bool) -> Self {
+        self.0.display_tag = show;
+        self
+    }
+
     fn new_header(&self) -> HeaderMap {
         match self.0.headers {
             Some(ref h) => h.to_owned(),
@@ -435,6 +469,7 @@ impl DownloaderBuilder {
             style_options: self.0.style_options,
             resumable: self.0.resumable,
             headers: self.0.headers,
+            display_tag: self.0.display_tag,
         }
     }
 }
@@ -448,6 +483,7 @@ impl Default for DownloaderBuilder {
             style_options: StyleOptions::default(),
             resumable: true,
             headers: None,
+            display_tag: true,
         })
     }
 }


### PR DESCRIPTION
# Pull Request

## Types of changes

- New feature (non-breaking change which adds functionality)

## Motivation

- I want to show info for each download.

## Description

<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

- Add a `display_tag` option to `Downloader`. When enabled, each child progress bar prepends a left-aligned, padded tag. (true by default)
- Add an optional `tag` field to `Download` so each download can carry a custom label (falls back to the filename when not set).

with tag:

<img width="857" height="84" alt="PixPin_2026-04-25_12-20-55" src="https://github.com/user-attachments/assets/f9da5113-b411-4d3b-82b1-ec6965e52800" />
<br/>

without tag (same as origin):

<img width="698" height="90" alt="PixPin_2026-04-25_12-26-56" src="https://github.com/user-attachments/assets/02f3def4-55e2-4063-a6e0-0d1d127a963a" />


<!--
Motivation and Context
Why is this change required? What problem does it solve?
-->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the Changelog (if applicable)
